### PR TITLE
feat : Python upgrade and fix docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM apache/airflow:2.10.5-python3.9
+FROM docker.io/apache/airflow:2.10.5-python3.12
 
+# update pip
+RUN pip3 install --upgrade pip
+
+# install requirements
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
# :grey_question: About

This PR : 

- Switches to Python `3.12`
- Upgrades `pip`
- Specifies explicitly the registry

# :moneybag: Benefits

Its helps install more deps than with the actual Python version and gets us up-to-date with `pip`